### PR TITLE
Fix transpose bug in ensemble/load.m

### DIFF
--- a/@ensemble/load.m
+++ b/@ensemble/load.m
@@ -101,8 +101,9 @@ varOutputLimits = dash.indices.limits(obj.lengths(v));
 
 % Get blocks of contiguous variables. These variables occupy adjacent
 % memory blocks in the .ens file, and can be loaded using strided loading
-lastVars = find( diff(v)~=1 )';
-blockLimits = [[1;lastVars+1], [lastVars;nVariables]];
+lastVars = find(diff(v)~=1);
+lastVars = lastVars(:);   % ensure column vector
+blockLimits = [[1; lastVars+1], [lastVars; nVariables]];
 nBlocks = size(blockLimits, 1);
 
 % Load each block of contiguous variables. Get the index of the variable


### PR DESCRIPTION
This fixes a vertcat error in ensemble/load.m when loading more than two blocks of variables with useVariables. This just ensures the block limits are columns. I've done some ad hoc testing with several localizations and two time periods and it works well!
